### PR TITLE
update install and default value in manifest to add a / at the end of path if missing

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,8 +25,8 @@
                 "ask": {
                     "en": "Choose a path for Radicale"
                 },
-                "example": "/sync",
-                "default": "/sync"
+                "example": "/sync/",
+                "default": "/sync/"
             }
         ]
     }

--- a/scripts/install
+++ b/scripts/install
@@ -4,6 +4,11 @@
 domain=$1
 path=$2
 
+# Add ending / to path if missing
+if [[ ! $path =~ /$ ]]; then
+    path=$path/
+fi
+
 # Check domain/path availability
 sudo yunohost app checkurl $domain$path -a radicale
 sudo yunohost app setting radicale skipped_uris -v "$path"


### PR DESCRIPTION
Just small changes to add a slash at the end of the path if it's missing, as mentioned in the /etc/radicale/config file before the base_prefix : 

```
# Root URL of Radicale (starting and ending with a slash)
```

I also changed the example and default value in the manifest.json file.
